### PR TITLE
fix(socket): remove unnecessary factory injection

### DIFF
--- a/app/templates/client/services/socket(sockets)/socket.mock.js
+++ b/app/templates/client/services/socket(sockets)/socket.mock.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('<%= appname %>')
-  .factory('Socket', function (socketFactory) {
+  .factory('Socket', function () {
 
     return {
       socket: {


### PR DESCRIPTION
The socketFactory was injected but not used so it produces a JShint error.