### PR TITLE
typo crash serve on ubuntu 14.04

### DIFF
--- a/app/templates/tasks/serve.js
+++ b/app/templates/tasks/serve.js
@@ -70,7 +70,7 @@ module.exports = {
   bsync: function () {
     bsync.init({
       proxy: 'localhost:9000',
-      browser: process.env.BROWSER || 'google chrome',
+      browser: process.env.BROWSER || 'google-chrome',
       online: false,
       notify: false,
       watchOptions: {


### PR DESCRIPTION

![captura de pantalla de 2015-04-25 13 18 27](https://cloud.githubusercontent.com/assets/2611201/7334096/b38c2cec-eb4d-11e4-96b2-7dc36ad01a6b.png)
Error: spawn google chrome ENOENT
  at exports._errnoException (util.js:746:11)
  at Process.ChildProcess._handle.onexit (child_process.js:1053:32)
  at child_process.js:1144:20
  at process._tickDomainCallback (node.js:381:11)