### PR TITLE
modify test task so the files are injected from bower-main-files.

### DIFF
--- a/app/templates/tasks/test.js(hasTests)
+++ b/app/templates/tasks/test.js(hasTests)
@@ -71,7 +71,10 @@ function testClient (done) {
           'client/services/**/*.js',
           'client/directives/**/*.js',
           'client/directives/**/*.html',
-          'client/filters/**/*.js']), {
+          'client/filters/**/*.js',
+          '!client/views/**/*.e2e.js',
+          '!client/services/socket/socket.service.js',
+          '!**/angular-scenario.js']), {
         read: false,
         base: 'client'
       }), {

--- a/app/templates/tasks/test.js(hasTests)
+++ b/app/templates/tasks/test.js(hasTests)
@@ -11,6 +11,10 @@ var protractor = require('gulp-protractor');<% } %><% if (filters.karma) { %>
 var karma      = require('karma').server;<% } %><% if (filters.mocha) { %>
 var plumber    = require('gulp-plumber');
 var mocha      = require('gulp-mocha');<% } %>
+var bowerFiles = require('main-bower-files');
+var inject     = require('gulp-inject');
+var es         = require('event-stream');
+var toExclude  = require('./config/bowerFilesToExclude');
 
 /**
  * Log. With options.
@@ -56,9 +60,34 @@ function testClient (done) {
 
   log('Running client tests...', { padding: true });
 <% if (filters.karma) { %>
-  karma.start({
-    configFile: __dirname + '/../karma.conf.js'
-  }, done);<% } else { %>
+  /// Inject bowerfiles into the karma config file.
+  gulp.src('karma.conf.js')
+    .pipe(inject(
+      gulp.src(bowerFiles({
+        debugging: false
+      }).concat(['client/app.js',
+          'client/views/**/*.js',
+          'client/services/**/*.js',
+          'client/directives/**/*.js',
+          'client/directives/**/*.html',
+          'client/filters/**/*.js']), {
+        read: false,
+        base: 'client'
+      }), {
+        ignorePath: toExclude,
+        starttag: 'files: [',
+        endtag: ']',
+        transform: function (filepath, file, i, length) {
+          return '"' + file.relative + '"' + (i + 1 < length ? ',' : '');
+        }
+      }))
+    .pipe(gulp.dest('.'))
+    .pipe(es.wait(function () {
+      karma.start({
+        configFile: __dirname + '/../karma.conf.js'
+      }, done);
+    }));
+  <% } else { %>
   done();
 <% } %>
 }

--- a/app/templates/tasks/test.js(hasTests)
+++ b/app/templates/tasks/test.js(hasTests)
@@ -63,8 +63,9 @@ function testClient (done) {
   /// Inject bowerfiles into the karma config file.
   gulp.src('karma.conf.js')
     .pipe(inject(
-      gulp.src(bowerFiles({
-        debugging: false
+      gulp.src(bowerFiles('**/*.js', {
+        debugging: false,
+        includeDev: true
       }).concat(['client/app.js',
           'client/views/**/*.js',
           'client/services/**/*.js',


### PR DESCRIPTION
All of the other tasks that use bower files were injecting them.  This adds that same capability.  Based on the [gulp-inject example](https://www.npmjs.com/package/gulp-inject#injecting-all-javascript-files-into-a-karma-config-file). 