### PR TITLE
fix(core): remove wrong way to watch directory

### DIFF
--- a/app/templates/tasks/watch.js
+++ b/app/templates/tasks/watch.js
@@ -47,22 +47,17 @@ module.exports = function () {<% if (filters.reload === 'livereload') { %>
   });
 
   var coreFiles = [
-    'client/views',
     'client/views/**/*.html',
     'client/views/**/*.js',
     '!client/views/**/*.scss',
     '!client/views/**/*.spec.js',
     '!client/views/**/*.e2e.js',
-    'client/directives',
     'client/directives/**/*.html',
     'client/directives/**/*.js',
     '!client/directives/**/*.spec.js',
-    'client/services',
     'client/services/**/*.js',
     '!client/services/**/*.spec.js',
-    'client/animations',
     'client/animations/*.js',
-    'client/filters',
     'client/filters/**/*.js',
     '!client/filters/**/*.spec.js'
   ];


### PR DESCRIPTION
Removing wrong way to watch directories with gulp-watch.

Theses lines create error below when you add another file extension that those who are in array:

```
/Users/valentin/test2/node_modules/gulp-watch/node_modules/glob/node_modules/minimatch/minimatch.js:108
    throw new TypeError('glob pattern string required')
          ^
TypeError: glob pattern string required
    at new Minimatch (/Users/valentin/test2/node_modules/gulp-watch/node_modules/glob/node_modules/minimatch/minimatch.js:108:11)
    at setopts (/Users/valentin/test2/node_modules/gulp-watch/node_modules/glob/common.js:112:20)
    at new Glob (/Users/valentin/test2/node_modules/gulp-watch/node_modules/glob/glob.js:117:3)
    at EventEmitter.processEvent (/Users/valentin/test2/node_modules/gulp-watch/index.js:92:35)
    at EventEmitter.emit (events.js:110:17)
    at EventEmitter.<anonymous> (/Users/valentin/test2/node_modules/gulp-watch/node_modules/chokidar/index.js:137:38)
    at EventEmitter.FSWatcher._emit (/Users/valentin/test2/node_modules/gulp-watch/node_modules/chokidar/index.js:152:5)
    at EventEmitter.<anonymous> (/Users/valentin/test2/node_modules/gulp-watch/node_modules/chokidar/lib/fsevents-handler.js:172:14)
    at addOrChange (/Users/valentin/test2/node_modules/gulp-watch/node_modules/chokidar/lib/fsevents-handler.js:177:7)
    at EventEmitter.<anonymous> (/Users/valentin/test2/node_modules/gulp-watch/node_modules/chokidar/lib/fsevents-handler.js:203:16)
```

more infos here: http://stackoverflow.com/questions/21689334/gulp-globbing-how-to-watch-everything-below-directory