### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,6 @@
     "mocha": "*",
     "spritesmith-cli": "^1.1.1"
   },
-  "peerDependencies": {
-    "yo": ">=1.4.0"
-  },
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
Removing PeerDependency solves the problem "UNMET PEER DEPENDENCY" as described below:

$ npm install -g generator-bangular
npm WARN deprecated native-or-bluebird@1.2.0: please use 'any-promise' instead
/Users/akaplan/.npm-packages/lib
├── generator-bangular@1.0.0
└── UNMET PEER DEPENDENCY yo@>=1.4.0

npm WARN generator-bangular@1.0.0 requires a peer of yo@>=1.4.0 but none was installed.

$ yo --version
1.7.0
